### PR TITLE
Document experimental status of Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial implementation of Aegis-Assets compliance-first extraction platform
 - Core Rust library with plugin architecture
 - Unity plugin with basic format detection and extraction
-- Python bindings via PyO3
+- Python bindings via PyO3 (stub module; functionality pending)
 - Command-line interface with extract, recipe, and compliance commands
 - Compliance framework with publisher risk profiles
 - Patch recipe system for legal asset distribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ For unclear cases, follow this decision tree:
 ### Prerequisites
 
 - **Rust 1.70+**: Latest stable toolchain
-- **Python 3.8+**: For Python bindings development  
+- **Python 3.8+**: Optional (bindings are experimental and currently stubbed)
 - **Git**: Version control
 - **IDE**: VSCode with rust-analyzer recommended
 

--- a/DEVELOPMENT_SUMMARY.md
+++ b/DEVELOPMENT_SUMMARY.md
@@ -4,7 +4,7 @@
 
 ### Core Architecture ✅ Complete
 - **aegis-core**: Rust library with compliance-first extraction engine
-- **aegis-python**: Python bindings via PyO3 for cross-language support  
+- **aegis-python**: Experimental PyO3 module (currently stub; bindings pending)
 - **aegis-cli**: Full-featured command-line interface
 - **Plugin system**: Extensible architecture with Unity plugin implemented
 
@@ -33,7 +33,7 @@
 - [x] Unity plugin (functional but basic)
 - [x] Compliance framework
 - [x] CLI interface
-- [x] Python bindings
+- [ ] Python bindings (current module is a stub)
 - [x] Documentation
 - [x] CI/CD pipeline
 - [ ] Unity plugin refinement (stub implementation needs full format support)

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ cargo build --release
 ./target/release/aegis db stats
 ```
 
+### ⚠️ Python bindings status
+
+The `aegis-python` crate currently provides a stub PyO3 module. Functional bindings for configuring and running extractions from Python are still in development, so all workflows should use the Rust CLI or core library for the time being.
+
 ### 🌐 **Web Dashboard**
 
 After starting the API server, open `api_demo.html` in your browser to access the interactive web dashboard with:

--- a/SPRINT_SUMMARY.md
+++ b/SPRINT_SUMMARY.md
@@ -42,8 +42,8 @@
 
 #### ✅ **Documentation & Examples**
 - **Plugin README**: Complete documentation with usage examples
-- **Python Example Script**: Practical demonstration of Unity asset extraction
-- **API Documentation**: Rust and Python API examples
+- **Python Example Script**: _Planned; pending functional bindings_
+- **API Documentation**: Rust examples available (Python API pending)
 - **Troubleshooting Guide**: Common issues and solutions
 
 ### 🏗️ Technical Architecture Completed
@@ -100,7 +100,7 @@ The Unity plugin can now:
 - **Extensible**: Easy to add new Unity versions and asset types
 
 ### ✅ **Developer Experience**
-- **Clear APIs**: Both Rust and Python interfaces available
+- **Clear APIs**: Rust interface available; Python bindings still experimental
 - **Rich Documentation**: Complete guides and examples
 - **Testing Tools**: Automated validation and benchmarking
 - **Build Automation**: One-command build and test pipeline

--- a/aegis-plugins/unity/README.md
+++ b/aegis-plugins/unity/README.md
@@ -60,23 +60,9 @@ aegis extract game.unity3d --filter "*.png,*.gltf" --plugin unity
 aegis extract game.unity3d --compliance-check --plugin unity
 ```
 
-### Python API
-```python
-from aegis import UnityPlugin
+### Python API (planned)
 
-# Open Unity file
-plugin = UnityPlugin()
-archive = plugin.open("sharedassets0.assets")
-
-# List available assets
-for entry in archive.list_entries():
-    print(f"{entry.name} ({entry.file_type}) - {entry.size_uncompressed} bytes")
-
-# Extract and convert specific asset
-texture_data = archive.read_converted_entry("Texture2D_12345")
-with open("texture.png", "wb") as f:
-    f.write(texture_data)
-```
+The Unity plugin does not yet expose a functional Python interface. The `aegis-python` crate currently contains placeholder bindings while we design a safe API surface. For now, use the Rust CLI or library interfaces.
 
 ### Rust API
 ```rust

--- a/aegis-python/Cargo.toml
+++ b/aegis-python/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Python bindings for Aegis-Assets"
+description = "Experimental Python bindings for Aegis-Assets (API surface not yet stable)"
+publish = false
 keywords = ["python", "bindings", "game", "assets"]
 
 [lib]


### PR DESCRIPTION
## Summary
- clarify across development and sprint summaries that the aegis-python crate is still a stub
- add warnings in the main README and Unity plugin docs about the lack of a usable Python API
- mark the aegis-python package metadata as experimental and non-publishable

## Testing
- cargo test *(fails: existing aegis-plugins/unity integration test imports are unresolved)*

------
https://chatgpt.com/codex/tasks/task_e_68cf635227048332926d3eff949c581c