### PR TITLE
Track extraction outputs and surface CLI conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "walkdir",
 ]
 

--- a/aegis-cli/Cargo.toml
+++ b/aegis-cli/Cargo.toml
@@ -47,3 +47,4 @@ api = ["aegis-core/api"]
 
 [dev-dependencies]
 tempfile = "3.8"
+uuid = "1"

--- a/aegis-core/src/extract.rs
+++ b/aegis-core/src/extract.rs
@@ -1,38 +1,39 @@
 use crate::{
-    archive::ComplianceRegistry,
+    archive::{ComplianceRegistry, ConvertedEntry, EntryMetadata},
     compliance::{ComplianceChecker, ComplianceResult},
     resource::Resource,
-    PluginRegistry, Config,
+    Config, PluginRegistry,
 };
 use anyhow::Result;
-use std::path::{Path, PathBuf};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
-use tracing::{info, error};
+use tracing::{error, info, warn};
 
 /// Errors that can occur during extraction
 #[derive(Debug, Error)]
 pub enum ExtractionError {
     #[error("No suitable plugin found for file: {0}")]
     NoSuitablePlugin(PathBuf),
-    
+
     #[error("Compliance check failed: {0}")]
     ComplianceViolation(String),
-    
+
     #[error("File not found: {0}")]
     FileNotFound(PathBuf),
-    
+
     #[error("Invalid file format: {0}")]
     InvalidFormat(String),
-    
+
     #[error("Memory limit exceeded (limit: {limit}MB, required: {required}MB)")]
     MemoryLimitExceeded { limit: usize, required: usize },
-    
+
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
-    
+
     #[error("Plugin error: {plugin}: {error}")]
     PluginError { plugin: String, error: String },
-    
+
     #[error("Generic error: {0}")]
     Generic(#[from] anyhow::Error),
 }
@@ -42,6 +43,8 @@ pub enum ExtractionError {
 pub struct ExtractionResult {
     /// Path to the source file
     pub source_path: PathBuf,
+    /// Base directory where raw/converted assets were written
+    pub output_dir: PathBuf,
     /// Extracted resources
     pub resources: Vec<Resource>,
     /// Warnings encountered during extraction
@@ -95,9 +98,13 @@ impl Extractor {
             config: Config::default(),
         }
     }
-    
+
     /// Create a new extractor with custom config
-    pub fn with_config(plugin_registry: PluginRegistry, compliance_registry: ComplianceRegistry, config: Config) -> Self {
+    pub fn with_config(
+        plugin_registry: PluginRegistry,
+        compliance_registry: ComplianceRegistry,
+        config: Config,
+    ) -> Self {
         let compliance_checker = ComplianceChecker::from_registry(compliance_registry);
         Self {
             plugin_registry,
@@ -105,89 +112,129 @@ impl Extractor {
             config,
         }
     }
-    
+
     /// Get a reference to the plugin registry
     pub fn plugin_registry(&self) -> &PluginRegistry {
         &self.plugin_registry
     }
-    
+
     /// Get a reference to the compliance checker
     pub fn compliance_checker(&self) -> &ComplianceChecker {
         &self.compliance_checker
     }
-    
+
     /// Extract assets from a file
     pub fn extract_from_file(
         &mut self,
         source_path: &Path,
-        _output_dir: &Path,
+        output_dir: &Path,
     ) -> Result<ExtractionResult, ExtractionError> {
         let start_time = std::time::Instant::now();
-        
+
         info!("Starting extraction from: {}", source_path.display());
-        
+
         // Check if file exists
         if !source_path.exists() {
             return Err(ExtractionError::FileNotFound(source_path.to_path_buf()));
         }
-        
+
+        fs::create_dir_all(output_dir)?;
+
         // Read file header for plugin detection
         let mut file = std::fs::File::open(source_path)?;
         let mut header = vec![0u8; 1024];
         use std::io::Read;
         let bytes_read = file.read(&mut header)?;
         header.truncate(bytes_read);
-        
+
         // Find suitable plugin using registry
         info!("Detecting file format...");
-        let plugin_factory = self.plugin_registry
+        let plugin_factory = self
+            .plugin_registry
             .find_handler(source_path, &header)
             .ok_or_else(|| ExtractionError::NoSuitablePlugin(source_path.to_path_buf()))?;
-        
-        info!("Using plugin: {} v{}", plugin_factory.name(), plugin_factory.version());
-        
+
+        info!(
+            "Using plugin: {} v{}",
+            plugin_factory.name(),
+            plugin_factory.version()
+        );
+        let plugin_name = plugin_factory.name().to_string();
+
         // Check compliance before extraction
-        let game_id = source_path.file_stem()
+        let game_id = source_path
+            .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
-        let format = source_path.extension()
+        let format = source_path
+            .extension()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
-            
-        let compliance_result = self.compliance_checker.check_extraction_allowed(game_id, format);
-        
+
+        let compliance_result = self
+            .compliance_checker
+            .check_extraction_allowed(game_id, format);
+
         // Handle compliance result
         let (is_allowed, warnings, recommendations, risk_level) = match &compliance_result {
-            ComplianceResult::Allowed { warnings, recommendations, profile } => {
-                (true, warnings.clone(), recommendations.clone(), profile.enforcement_level)
-            }
-            ComplianceResult::AllowedWithWarnings { warnings, recommendations, profile } => {
-                (true, warnings.clone(), recommendations.clone(), profile.enforcement_level)
-            }
-            ComplianceResult::HighRiskWarning { warnings, profile, .. } => {
-                return Err(ExtractionError::ComplianceViolation(
-                    format!("High-risk extraction requires explicit consent. {}", warnings.join("; "))
-                ));
+            ComplianceResult::Allowed {
+                warnings,
+                recommendations,
+                profile,
+            } => (
+                true,
+                warnings.clone(),
+                recommendations.clone(),
+                profile.enforcement_level,
+            ),
+            ComplianceResult::AllowedWithWarnings {
+                warnings,
+                recommendations,
+                profile,
+            } => (
+                true,
+                warnings.clone(),
+                recommendations.clone(),
+                profile.enforcement_level,
+            ),
+            ComplianceResult::HighRiskWarning { warnings, .. } => {
+                return Err(ExtractionError::ComplianceViolation(format!(
+                    "High-risk extraction requires explicit consent. {}",
+                    warnings.join("; ")
+                )));
             }
             ComplianceResult::Blocked { reason, .. } => {
                 return Err(ExtractionError::ComplianceViolation(reason.clone()));
             }
         };
-        
+
         if !warnings.is_empty() {
             for warning in &warnings {
                 info!("Compliance warning: {}", warning);
             }
         }
-        
+
         // Create handler and extract resources
-        let handler = plugin_factory.create_handler(source_path)?;
-        let entries = handler.list_entries()?;
-        
+        let handler = plugin_factory.create_handler(source_path).map_err(|e| {
+            ExtractionError::PluginError {
+                plugin: plugin_name.clone(),
+                error: e.to_string(),
+            }
+        })?;
+        let entries = handler
+            .list_entries()
+            .map_err(|e| ExtractionError::PluginError {
+                plugin: plugin_name.clone(),
+                error: e.to_string(),
+            })?;
+
         info!("Found {} entries in archive", entries.len());
-        
+
         // Convert entries to resources (simplified)
         let mut resources = Vec::new();
+        let mut extraction_warnings = Vec::new();
+        let mut total_bytes = 0u64;
+
         for entry in entries {
             let resource_type = match entry.file_type.as_deref() {
                 Some("texture") => crate::resource::ResourceType::Texture,
@@ -195,49 +242,114 @@ impl Extractor {
                 Some("audio") => crate::resource::ResourceType::Audio,
                 _ => crate::resource::ResourceType::Generic,
             };
-            
-            let resource = crate::resource::Resource {
-                id: entry.id.0.clone(),
-                name: entry.name.clone(),
+
+            let mut resource = Resource::new(
+                entry.id.0.clone(),
+                entry.name.clone(),
                 resource_type,
-                size: entry.size_uncompressed,
-                format: entry.file_type.unwrap_or_else(|| "unknown".to_string()),
-                metadata: std::collections::HashMap::new(),
-            };
+                entry.size_uncompressed,
+                entry
+                    .file_type
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+            );
+
+            resource.metadata.insert(
+                "archive_entry_path".to_string(),
+                entry.path.display().to_string(),
+            );
+
+            let raw_bytes =
+                handler
+                    .read_entry(&entry.id)
+                    .map_err(|e| ExtractionError::PluginError {
+                        plugin: plugin_name.clone(),
+                        error: e.to_string(),
+                    })?;
+
+            let relative_path = sanitize_entry_path(&entry);
+            let raw_output_path = output_dir.join(&relative_path);
+            if let Some(parent) = raw_output_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(&raw_output_path, &raw_bytes)?;
+
+            resource.set_raw_path(&raw_output_path);
+            resource.metadata.insert(
+                "raw_output_path".to_string(),
+                raw_output_path.display().to_string(),
+            );
+            resource.size = raw_bytes.len() as u64;
+            total_bytes += raw_bytes.len() as u64;
+
+            match handler.read_converted_entry(&entry.id) {
+                Ok(Some(ConvertedEntry {
+                    filename,
+                    data,
+                    converted,
+                })) => {
+                    if converted {
+                        let converted_dir = output_dir.join("converted");
+                        fs::create_dir_all(&converted_dir)?;
+                        let converted_output_path = converted_dir.join(&filename);
+                        fs::write(&converted_output_path, &data)?;
+                        resource.add_converted_path(&converted_output_path);
+                        resource.metadata.insert(
+                            format!(
+                                "converted_output_{}",
+                                resource.converted_output_paths().len()
+                            ),
+                            converted_output_path.display().to_string(),
+                        );
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(
+                        "Failed to produce converted output for {}: {}",
+                        entry.name, e
+                    );
+                    extraction_warnings.push(format!(
+                        "Failed to convert {} via plugin {}: {}",
+                        entry.name, plugin_name, e
+                    ));
+                }
+            }
+
             resources.push(resource);
         }
-        
+
         let duration = start_time.elapsed();
-        let total_bytes: u64 = resources.iter().map(|r| r.size).sum();
         let metrics = ExtractionMetrics {
             duration_ms: duration.as_millis() as u64,
             peak_memory_mb: 64, // TODO: Implement actual memory monitoring
             files_processed: resources.len(),
             bytes_extracted: total_bytes,
         };
-        
+
         let compliance_info = ComplianceInfo {
             is_compliant: is_allowed,
             risk_level,
             warnings,
             recommendations,
         };
-        
+
         info!(
             "Extraction completed in {}ms, {} resources extracted",
             metrics.duration_ms,
             resources.len()
         );
-        
+
         Ok(ExtractionResult {
             source_path: source_path.to_path_buf(),
+            output_dir: output_dir.to_path_buf(),
             resources,
-            warnings: vec![],
+            warnings: extraction_warnings,
             compliance_info,
             metrics,
         })
     }
-    
+
     /// Batch extract multiple files
     pub fn extract_batch(
         &mut self,
@@ -245,7 +357,7 @@ impl Extractor {
         output_dir: &Path,
     ) -> Result<Vec<ExtractionResult>, ExtractionError> {
         let mut results = Vec::new();
-        
+
         for source in sources {
             match self.extract_from_file(source, output_dir) {
                 Ok(result) => results.push(result),
@@ -255,10 +367,10 @@ impl Extractor {
                 }
             }
         }
-        
+
         Ok(results)
     }
-    
+
     /// Get extraction statistics
     pub fn get_stats(&self) -> ExtractionStats {
         ExtractionStats {
@@ -268,6 +380,29 @@ impl Extractor {
             average_processing_time_ms: 0,
         }
     }
+}
+
+fn sanitize_entry_path(entry: &EntryMetadata) -> PathBuf {
+    let candidate = if entry.path.as_os_str().is_empty() {
+        PathBuf::from(entry.name.clone())
+    } else {
+        entry.path.clone()
+    };
+
+    let mut sanitized = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            Component::Normal(part) => sanitized.push(part),
+            Component::CurDir => {}
+            Component::RootDir | Component::Prefix(_) | Component::ParentDir => {}
+        }
+    }
+
+    if sanitized.as_os_str().is_empty() {
+        sanitized.push(&entry.name);
+    }
+
+    sanitized
 }
 
 /// Overall extraction statistics
@@ -286,49 +421,207 @@ unsafe impl Sync for Extractor {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+    use crate::archive::{
+        ArchiveHandler, ComplianceLevel, ComplianceProfile, ConvertedEntry, EntryId, EntryMetadata,
+        PluginInfo, Provenance,
+    };
+    use crate::PluginFactory;
+    use chrono::Utc;
     use std::fs::File;
     use std::io::Write;
-    
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
     #[test]
     fn test_extractor_creation() {
         let plugin_registry = crate::PluginRegistry::new();
         let compliance = ComplianceRegistry::new();
         let extractor = Extractor::new(plugin_registry, compliance);
         let stats = extractor.get_stats();
-        
+
         assert_eq!(stats.files_processed, 0);
     }
-    
+
     #[test]
     fn test_file_not_found() {
         let plugin_registry = crate::PluginRegistry::new();
         let compliance = ComplianceRegistry::new();
         let mut extractor = Extractor::new(plugin_registry, compliance);
         let temp_dir = TempDir::new().unwrap();
-        
-        let result = extractor.extract_from_file(
-            &temp_dir.path().join("nonexistent.file"),
-            temp_dir.path(),
-        );
-        
+
+        let result =
+            extractor.extract_from_file(&temp_dir.path().join("nonexistent.file"), temp_dir.path());
+
         assert!(matches!(result, Err(ExtractionError::FileNotFound(_))));
     }
-    
+
     #[test]
     fn test_mock_extraction() {
         let plugin_registry = crate::PluginRegistry::new();
         let compliance = ComplianceRegistry::new();
         let mut extractor = Extractor::new(plugin_registry, compliance);
         let temp_dir = TempDir::new().unwrap();
-        
+
         // Create a dummy file
         let test_file = temp_dir.path().join("test.dat");
         let mut file = File::create(&test_file).unwrap();
         file.write_all(b"test data").unwrap();
-        
+
         let result = extractor.extract_from_file(&test_file, temp_dir.path());
         // This will likely fail since we have no plugins registered, but that's expected
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn extraction_writes_outputs() {
+        let mut plugin_registry = crate::PluginRegistry::new();
+        plugin_registry.register_plugin(Box::new(MockFactory));
+        let compliance = ComplianceRegistry::new();
+        let mut extractor = Extractor::new(plugin_registry, compliance);
+        let temp_dir = TempDir::new().unwrap();
+
+        let source = temp_dir.path().join("bundle.mock");
+        std::fs::write(&source, b"MOCKDATA").unwrap();
+        let output_dir = temp_dir.path().join("out");
+
+        let result = extractor
+            .extract_from_file(&source, &output_dir)
+            .expect("extraction should succeed");
+
+        assert_eq!(result.resources.len(), 1);
+        assert_eq!(result.output_dir, output_dir);
+
+        let resource = &result.resources[0];
+        let raw_path = resource.raw_output_path().expect("raw output path");
+        assert!(raw_path.exists());
+        assert!(raw_path.starts_with(&result.output_dir));
+        assert_eq!(resource.size, MOCK_RAW.len() as u64);
+
+        let converted = resource.converted_output_paths();
+        assert_eq!(converted.len(), 1);
+        assert!(converted[0].exists());
+    }
+
+    const MOCK_RAW: &[u8] = &[42u8; 64];
+
+    struct MockFactory;
+
+    impl PluginFactory for MockFactory {
+        fn name(&self) -> &str {
+            "Mock"
+        }
+
+        fn version(&self) -> &str {
+            "1.0.0"
+        }
+
+        fn supported_extensions(&self) -> Vec<&str> {
+            vec!["mock"]
+        }
+
+        fn can_handle(&self, bytes: &[u8]) -> bool {
+            bytes.starts_with(b"MOCK") || !bytes.is_empty()
+        }
+
+        fn create_handler(&self, path: &Path) -> Result<Box<dyn ArchiveHandler>> {
+            Ok(Box::new(MockHandler::new(path)?))
+        }
+
+        fn compliance_info(&self) -> PluginInfo {
+            PluginInfo {
+                name: "Mock".to_string(),
+                version: "1.0.0".to_string(),
+                author: Some("Test".to_string()),
+                compliance_verified: true,
+            }
+        }
+    }
+
+    struct MockHandler {
+        compliance_profile: ComplianceProfile,
+        provenance: Provenance,
+    }
+
+    impl MockHandler {
+        fn new(path: &Path) -> Result<Self> {
+            let compliance_profile = ComplianceProfile {
+                publisher: "Mock Publisher".to_string(),
+                game_id: Some("mock_game".to_string()),
+                enforcement_level: ComplianceLevel::Permissive,
+                official_support: true,
+                bounty_eligible: false,
+                enterprise_warning: None,
+                mod_policy_url: None,
+                supported_formats: std::collections::HashMap::new(),
+            };
+
+            let source_bytes = std::fs::read(path)?;
+            let provenance = Provenance {
+                session_id: Uuid::new_v4(),
+                game_id: Some("mock_game".to_string()),
+                source_hash: blake3::hash(&source_bytes).to_hex().to_string(),
+                source_path: path.to_path_buf(),
+                compliance_profile: compliance_profile.clone(),
+                extraction_time: Utc::now(),
+                aegis_version: crate::VERSION.to_string(),
+                plugin_info: PluginInfo {
+                    name: "Mock".to_string(),
+                    version: "1.0.0".to_string(),
+                    author: Some("Test".to_string()),
+                    compliance_verified: true,
+                },
+            };
+
+            Ok(Self {
+                compliance_profile,
+                provenance,
+            })
+        }
+    }
+
+    impl ArchiveHandler for MockHandler {
+        fn detect(bytes: &[u8]) -> bool {
+            !bytes.is_empty()
+        }
+
+        fn open(path: &Path) -> Result<Self>
+        where
+            Self: Sized,
+        {
+            Self::new(path)
+        }
+
+        fn compliance_profile(&self) -> &ComplianceProfile {
+            &self.compliance_profile
+        }
+
+        fn list_entries(&self) -> Result<Vec<EntryMetadata>> {
+            Ok(vec![EntryMetadata {
+                id: EntryId::new("entry_1"),
+                name: "MockTexture".to_string(),
+                path: PathBuf::from("textures/mock_texture.bin"),
+                size_compressed: None,
+                size_uncompressed: MOCK_RAW.len() as u64,
+                file_type: Some("texture".to_string()),
+                last_modified: None,
+                checksum: None,
+            }])
+        }
+
+        fn read_entry(&self, _id: &EntryId) -> Result<Vec<u8>> {
+            Ok(MOCK_RAW.to_vec())
+        }
+
+        fn read_converted_entry(&self, _id: &EntryId) -> Result<Option<ConvertedEntry>> {
+            Ok(Some(ConvertedEntry {
+                filename: "mock_texture.png".to_string(),
+                data: b"converted".to_vec(),
+                converted: true,
+            }))
+        }
+
+        fn provenance(&self) -> &Provenance {
+            &self.provenance
+        }
     }
 }

--- a/aegis-core/src/lib.rs
+++ b/aegis-core/src/lib.rs
@@ -1,57 +1,64 @@
 //! # Aegis-Assets Core
-//! 
+//!
 //! Compliance-first platform for game asset extraction, preservation, and creative workflows.
-//! 
+//!
 //! This crate provides the core engine for Aegis-Assets, including:
 //! - Plugin architecture for extensible format support
 //! - Compliance-aware extraction with risk assessment
 //! - Resource type definitions for common game assets
 //! - Export capabilities to modern formats (glTF, KTX2, OGG)
-//! 
+//!
 //! ## Architecture
-//! 
+//!
 //! Aegis-Core is built around a plugin architecture where each game engine format
 //! is supported by implementing the `ArchiveHandler` trait. This allows for:
-//! 
+//!
 //! - **Extensibility**: New formats can be added without modifying core code
 //! - **Compliance**: Each plugin declares its legal risk level and compliance status
 //! - **Performance**: Rust's zero-cost abstractions enable high-performance extraction
 //! - **Safety**: Memory safety and error handling built into the type system
-//! 
+//!
 //! ## Quick Start
-//! 
+//!
 //! ```rust,no_run
 //! use aegis_core::{
-//!     archive::{ArchiveHandler, ComplianceRegistry},
+//!     archive::ComplianceRegistry,
 //!     extract::Extractor,
+//!     PluginRegistry,
 //! };
 //! use std::path::Path;
-//! 
-//! // Load compliance profiles
+//!
+//! # fn run() -> anyhow::Result<()> {
+//! // Load compliance profiles (falls back to defaults if directory missing)
 //! let compliance = ComplianceRegistry::load_from_directory(
 //!     Path::new("compliance-profiles")
-//! )?;
-//! 
+//! ).unwrap_or_else(|_| ComplianceRegistry::new());
+//!
 //! // Create extractor with compliance checking
-//! let mut extractor = Extractor::new(compliance);
-//! 
+//! let plugin_registry = PluginRegistry::new();
+//! let mut extractor = Extractor::new(plugin_registry, compliance);
+//!
 //! // Extract assets (automatically detects format and applies compliance)
 //! let results = extractor.extract_from_file(
 //!     Path::new("game.unity3d"),
-//!     Path::new("./output/")
-//! )?;
-//! 
-//! println!("Extracted {} assets", results.len());
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//!     Path::new("./output")
+//! );
+//!
+//! if let Ok(result) = results {
+//!     println!("Extracted {} assets", result.resources.len());
+//! }
+//! # Ok(())
+//! # }
+//! # run().unwrap();
 //! ```
 
 pub mod archive;
-pub mod resource;
-pub mod export;
 pub mod asset_db;
-pub mod extract;
 pub mod compliance;
+pub mod export;
+pub mod extract;
 pub mod patch;
+pub mod resource;
 
 #[cfg(feature = "api")]
 pub mod api;
@@ -60,17 +67,16 @@ pub mod test_integration;
 
 // Re-export commonly used types
 pub use archive::{
-    ArchiveHandler, ComplianceLevel, ComplianceProfile, ComplianceRegistry,
-    EntryId, EntryMetadata, FormatSupport, PluginInfo, Provenance,
+    ArchiveHandler, ComplianceLevel, ComplianceProfile, ComplianceRegistry, EntryId, EntryMetadata,
+    FormatSupport, PluginInfo, Provenance,
 };
-pub use resource::{
-    Resource, MeshResource, TextureResource, MaterialResource, 
-    AnimationResource, AudioResource, LevelResource,
-    TextureFormat, TextureUsage, BlendMode, LoopMode,
-};
-pub use extract::{Extractor, ExtractionResult, ExtractionError};
 pub use export::{ExportFormat, ExportOptions, Exporter};
+pub use extract::{ExtractionError, ExtractionResult, Extractor};
 pub use patch::{PatchRecipe, PatchRecipeBuilder};
+pub use resource::{
+    AnimationResource, AudioResource, BlendMode, LevelResource, LoopMode, MaterialResource,
+    MeshResource, Resource, TextureFormat, TextureResource, TextureUsage,
+};
 
 use anyhow::Result;
 use std::collections::HashMap;
@@ -86,17 +92,17 @@ pub const GIT_HASH: &str = match option_env!("VERGEN_GIT_SHA") {
 /// Initialize the Aegis-Core library with logging and telemetry
 pub fn init() -> Result<()> {
     // Initialize tracing subscriber for structured logging
-    tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .with_env_filter("aegis_core=info,aegis_plugins=info")
         .with_target(false)
         .with_thread_ids(true)
         .with_file(true)
         .with_line_number(true)
-        .init();
+        .try_init();
 
     info!("Initializing Aegis-Assets Core v{}", VERSION);
     info!("Git commit: {}", GIT_HASH);
-    
+
     Ok(())
 }
 
@@ -117,19 +123,19 @@ impl Clone for PluginRegistry {
 pub trait PluginFactory: Send + Sync {
     /// Get the name of this plugin
     fn name(&self) -> &str;
-    
+
     /// Get plugin version
     fn version(&self) -> &str;
-    
+
     /// Get supported file extensions
     fn supported_extensions(&self) -> Vec<&str>;
-    
+
     /// Check if this plugin can handle the given file
     fn can_handle(&self, bytes: &[u8]) -> bool;
-    
+
     /// Create a new archive handler instance
     fn create_handler(&self, path: &std::path::Path) -> Result<Box<dyn ArchiveHandler>>;
-    
+
     /// Get compliance information for this plugin
     fn compliance_info(&self) -> PluginInfo;
 }
@@ -141,35 +147,35 @@ impl PluginRegistry {
             handlers: HashMap::new(),
         }
     }
-    
+
     /// Load default plugins (Unity, etc.)
     pub fn load_default_plugins() -> Self {
         let mut registry = Self::new();
-        
+
         // Register Unity plugin
         #[cfg(feature = "unity-plugin")]
         {
             use aegis_unity_plugin::UnityPluginFactory;
             registry.register_plugin(Box::new(UnityPluginFactory));
         }
-        
+
         // Register Unreal plugin
         #[cfg(feature = "unreal-plugin")]
         {
             use aegis_unreal_plugin::UnrealPluginFactory;
             registry.register_plugin(Box::new(UnrealPluginFactory));
         }
-        
+
         registry
     }
-    
+
     /// Register a plugin factory
     pub fn register_plugin(&mut self, factory: Box<dyn PluginFactory>) {
         let name = factory.name().to_string();
         info!("Registering plugin: {} v{}", name, factory.version());
         self.handlers.insert(name, factory);
     }
-    
+
     /// Find a suitable plugin for the given file
     pub fn find_handler(&self, path: &std::path::Path, bytes: &[u8]) -> Option<&dyn PluginFactory> {
         // First try extension-based detection
@@ -180,17 +186,17 @@ impl PluginRegistry {
                 }
             }
         }
-        
+
         // Fall back to content-based detection
         for factory in self.handlers.values() {
             if factory.can_handle(bytes) {
                 return Some(factory.as_ref());
             }
         }
-        
+
         None
     }
-    
+
     /// Get all registered plugins
     pub fn list_plugins(&self) -> Vec<&dyn PluginFactory> {
         self.handlers.values().map(|f| f.as_ref()).collect()
@@ -256,37 +262,37 @@ impl AegisCore {
     /// Create a new Aegis-Core instance with default configuration
     pub fn new() -> Result<Self> {
         init()?;
-        
+
         Ok(Self {
             config: Config::default(),
             plugin_registry: PluginRegistry::new(),
             compliance_registry: ComplianceRegistry::new(),
         })
     }
-    
+
     /// Create Aegis-Core with custom configuration
     pub fn with_config(config: Config) -> Result<Self> {
         init()?;
-        
+
         Ok(Self {
             config,
             plugin_registry: PluginRegistry::new(),
             compliance_registry: ComplianceRegistry::new(),
         })
     }
-    
+
     /// Load compliance profiles from directory
     pub fn load_compliance_profiles(&mut self, dir: &std::path::Path) -> Result<()> {
         info!("Loading compliance profiles from: {}", dir.display());
         self.compliance_registry = ComplianceRegistry::load_from_directory(dir)?;
         Ok(())
     }
-    
+
     /// Register a plugin
     pub fn register_plugin(&mut self, factory: Box<dyn PluginFactory>) {
         self.plugin_registry.register_plugin(factory);
     }
-    
+
     /// Create an extractor instance
     pub fn create_extractor(&self) -> Extractor {
         Extractor::with_config(
@@ -295,7 +301,7 @@ impl AegisCore {
             self.config.clone(),
         )
     }
-    
+
     /// Get system information
     pub fn system_info(&self) -> SystemInfo {
         SystemInfo {
@@ -321,21 +327,21 @@ pub struct SystemInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_aegis_core_creation() {
         let core = AegisCore::new().expect("Failed to create AegisCore");
         let info = core.system_info();
-        
+
         assert_eq!(info.version, VERSION);
         assert_eq!(info.registered_plugins, 0); // No plugins registered yet
     }
-    
+
     #[test]
     fn test_plugin_registry() {
         let mut registry = PluginRegistry::new();
         assert_eq!(registry.list_plugins().len(), 0);
-        
+
         // Plugin registration would be tested with actual plugin implementations
     }
 }

--- a/aegis-core/src/test_integration.rs
+++ b/aegis-core/src/test_integration.rs
@@ -1,6 +1,5 @@
-use crate::{AegisCore, PluginRegistry, archive::ComplianceRegistry};
-use crate::extract::{Extractor, ExtractionError};
-use std::path::Path;
+use crate::extract::{ExtractionError, Extractor};
+use crate::{archive::ComplianceRegistry, AegisCore, PluginRegistry};
 use tempfile::TempDir;
 
 /// Integration test for the core extraction pipeline
@@ -12,15 +11,15 @@ mod tests {
     fn test_extractor_creation() {
         let plugin_registry = PluginRegistry::new();
         let compliance_registry = ComplianceRegistry::new();
-        
+
         let _extractor = Extractor::new(plugin_registry, compliance_registry);
         // If we get here, the extractor was created successfully
     }
 
     #[test]
     fn test_aegis_core_creation() {
-        let mut aegis = AegisCore::new();
-        
+        let aegis = AegisCore::new().expect("Failed to initialize AegisCore");
+
         // Test that we can get system info
         let info = aegis.system_info();
         assert_eq!(info.registered_plugins, 0); // No plugins registered yet
@@ -31,17 +30,17 @@ mod tests {
     fn test_extraction_with_no_plugins() {
         let plugin_registry = PluginRegistry::new();
         let compliance_registry = ComplianceRegistry::new();
-        
+
         let mut extractor = Extractor::new(plugin_registry, compliance_registry);
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("test.dat");
-        
+
         // Create a dummy file
         std::fs::write(&test_file, b"dummy content").unwrap();
-        
+
         // Should fail because no plugins are registered
         let result = extractor.extract_from_file(&test_file, temp_dir.path());
-        
+
         match result {
             Err(ExtractionError::NoSuitablePlugin(_)) => {
                 // This is expected - no plugins registered


### PR DESCRIPTION
## Summary
- track extracted resource outputs on disk and expose them via `ExtractionResult`
- update the CLI extraction workflow to report and reuse saved outputs with integration coverage
- reinstate the Unity plugin conversion hook so converted files accompany raw payloads

## Testing
- cargo test -p aegis-core -p aegis-cli

------
https://chatgpt.com/codex/tasks/task_e_68cf631f26288332b337fcd0d0f61fd6