### PR TITLE
Add BC texture decompression for exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "bcdec_rs",
  "blake3",
  "byteorder",
  "chrono",
@@ -342,6 +343,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bcdec_rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09c37bc0e9f0924b7dae9988265ef3c76c88538f41a3b06caf4bed07cee5226"
 
 [[package]]
 name = "bit-set"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ nom = "7.1"
 gltf-json = "1.4"
 image = { version = "0.24", features = ["png", "jpeg"] }
 basis-universal = "0.3"
+bcdec_rs = "0.2"
 
 # Compression
 flate2 = "1.0"

--- a/aegis-core/Cargo.toml
+++ b/aegis-core/Cargo.toml
@@ -30,6 +30,7 @@ lz4_flex.workspace = true
 xz2.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+bcdec_rs.workspace = true
 
 # Additional core-specific dependencies
 walkdir = "2.4"

--- a/aegis-core/src/lib.rs
+++ b/aegis-core/src/lib.rs
@@ -86,13 +86,13 @@ pub const GIT_HASH: &str = match option_env!("VERGEN_GIT_SHA") {
 /// Initialize the Aegis-Core library with logging and telemetry
 pub fn init() -> Result<()> {
     // Initialize tracing subscriber for structured logging
-    tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .with_env_filter("aegis_core=info,aegis_plugins=info")
         .with_target(false)
         .with_thread_ids(true)
         .with_file(true)
         .with_line_number(true)
-        .init();
+        .try_init();
 
     info!("Initializing Aegis-Assets Core v{}", VERSION);
     info!("Git commit: {}", GIT_HASH);

--- a/aegis-core/src/test_integration.rs
+++ b/aegis-core/src/test_integration.rs
@@ -1,6 +1,5 @@
-use crate::{AegisCore, PluginRegistry, archive::ComplianceRegistry};
-use crate::extract::{Extractor, ExtractionError};
-use std::path::Path;
+use crate::extract::{ExtractionError, Extractor};
+use crate::{archive::ComplianceRegistry, AegisCore, PluginRegistry};
 use tempfile::TempDir;
 
 /// Integration test for the core extraction pipeline
@@ -12,15 +11,15 @@ mod tests {
     fn test_extractor_creation() {
         let plugin_registry = PluginRegistry::new();
         let compliance_registry = ComplianceRegistry::new();
-        
+
         let _extractor = Extractor::new(plugin_registry, compliance_registry);
         // If we get here, the extractor was created successfully
     }
 
     #[test]
     fn test_aegis_core_creation() {
-        let mut aegis = AegisCore::new();
-        
+        let aegis = AegisCore::new().expect("create AegisCore");
+
         // Test that we can get system info
         let info = aegis.system_info();
         assert_eq!(info.registered_plugins, 0); // No plugins registered yet
@@ -31,17 +30,17 @@ mod tests {
     fn test_extraction_with_no_plugins() {
         let plugin_registry = PluginRegistry::new();
         let compliance_registry = ComplianceRegistry::new();
-        
+
         let mut extractor = Extractor::new(plugin_registry, compliance_registry);
         let temp_dir = TempDir::new().unwrap();
         let test_file = temp_dir.path().join("test.dat");
-        
+
         // Create a dummy file
         std::fs::write(&test_file, b"dummy content").unwrap();
-        
+
         // Should fail because no plugins are registered
         let result = extractor.extract_from_file(&test_file, temp_dir.path());
-        
+
         match result {
             Err(ExtractionError::NoSuitablePlugin(_)) => {
                 // This is expected - no plugins registered


### PR DESCRIPTION
## Summary
- add the bcdec_rs dependency so the exporter can decode block-compressed textures
- replace the texture export placeholder with real decoding for DXT1/3/5 and BC7 along with a shared helper
- extend the test suite with fixtures covering BC-compressed output and unwrap AegisCore creation in integration tests

## Testing
- `cargo test -p aegis-core --lib`


------
https://chatgpt.com/codex/tasks/task_e_68c8698a89cc83329ba4b982565c9791