### PR TITLE
Improve CLI selection prompt and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "blake3",
  "chrono",
  "clap",
+ "colored",
  "console",
  "indicatif",
  "serde",
@@ -537,6 +538,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "console"

--- a/aegis-cli/Cargo.toml
+++ b/aegis-cli/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber.workspace = true
 clap = { version = "4.4", features = ["derive"] }
 indicatif = "0.17"
 console = "0.15"
+colored = "2.1"
 
 [features]
 default = []

--- a/aegis-cli/src/main.rs
+++ b/aegis-cli/src/main.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use tracing::{info, error, warn};
 use walkdir;
 
+mod ui;
+
 #[derive(Parser)]
 #[command(name = "aegis")]
 #[command(about = "Compliance-first game asset extraction tool")]


### PR DESCRIPTION
## Summary
- add the missing `colored` dependency and wire the CLI's UI module into `main`
- rework `ui::select` to repeatedly prompt until a valid choice or empty cancellation using a testable helper
- add unit coverage for retrying after invalid input and returning `None` on cancel

## Testing
- cargo test -p aegis-cli

------
https://chatgpt.com/codex/tasks/task_e_68c869715de48332afd356fe36cde286